### PR TITLE
Add Japanese (ja-JP) support for the toolbox app

### DIFF
--- a/page/SettingsLangScreen.js
+++ b/page/SettingsLangScreen.js
@@ -9,6 +9,7 @@ const available_locales = {
   "pt-BR": "Português",
   "zh-CN": "简体中文",
   "zh-TW": "繁體中文",
+  "ja-JP": "日本語",
 };
 
 const { config } = getApp()._options.globalData;

--- a/utils/translations.js
+++ b/utils/translations.js
@@ -1,6 +1,7 @@
 import {strings as enStrings} from "./translations/en-US.js";
 import {strings as deStrings} from "./translations/de-DE.js";
 import {strings as esStrings} from "./translations/es-ES.js";
+import {strings as jpStrings} from "./translations/ja-JP.js";
 import {strings as ptStrings} from "./translations/pt-BR.js";
 import {strings as ruStrings} from "./translations/ru-RU.js";
 import {strings as cnStrings} from "./translations/zh-CN.js";
@@ -10,6 +11,7 @@ export function initTranslations(loadLocale) {
   loadLocale("en-US", enStrings);
   loadLocale("de-DE", deStrings);
   loadLocale("es-ES", esStrings);
+  loadLocale("ja-JP", jpStrings);
   loadLocale("pt-BR", ptStrings);
   loadLocale("ru-RU", ruStrings);
   loadLocale("zh-CN", cnStrings);


### PR DESCRIPTION
I translated into Japanese in [crowdin](https://crowdin.com/translate/zeppos-toolbox/65/en-ja) and finished translating all words at this time.